### PR TITLE
Fix issue with angular 4 + typescript 2.2 in AoT

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -29,14 +29,13 @@ export function _createReducer(dispatcher: DevtoolsDispatcher, reducer) {
   return new Reducer(dispatcher, reducer);
 }
 
-export function _createStateIfExtension(extension: any, injector: Injector) {
+export function _createStateIfExtension(extension: any, injector: Injector, initialState: any) {
   if (!!extension) {
     const devtools: StoreDevtools = injector.get(StoreDevtools);
 
     return _createState(devtools);
   }
   else {
-    const initialState: any = injector.get(INITIAL_STATE);
     const dispatcher: Dispatcher = injector.get(Dispatcher);
     const reducer: Reducer = injector.get(Reducer);
 
@@ -44,16 +43,14 @@ export function _createStateIfExtension(extension: any, injector: Injector) {
   }
 }
 
-export function _createReducerIfExtension(extension: any, injector: Injector) {
+export function _createReducerIfExtension(extension: any, injector: Injector, reducer: any) {
   if (!!extension) {
     const devtoolsDispatcher: DevtoolsDispatcher = injector.get(DevtoolsDispatcher);
-    const reducer: any = injector.get(INITIAL_REDUCER);
 
     return _createReducer(devtoolsDispatcher, reducer);
   }
   else {
     const dispatcher: Dispatcher = injector.get(Dispatcher);
-    const reducer: any = injector.get(INITIAL_REDUCER);
 
     return new Reducer(dispatcher, reducer);
   }


### PR DESCRIPTION
Fix these errors in AoT compilation after upgrading TypeScript version:
```
Error at .../src/app/app.module.ngfactory.ts:315:24: Supplied parameters do not match any signature of call target.
Error at .../src/app/app.module.ngfactory.ts:318:22: Supplied parameters do not match any signature of call target.
```